### PR TITLE
Fixup tests to run with newer PHPUnit

### DIFF
--- a/tests/unit/components/CSDClient/GetUserDataRequestTest.php
+++ b/tests/unit/components/CSDClient/GetUserDataRequestTest.php
@@ -15,31 +15,49 @@
  * @license http://www.gnu.org/licenses/agpl-3.0.html The GNU Affero General Public License V3.0
  */
 
-namespace OEModule\CSDClient\tests\unit\components\CSDClient;
+namespace OEModule\mehstaffdb\tests\unit\components\CSDClient;
+
+use OEModule\mehstaffdb\components\CSDClient\GetUserDataRequest;
 
 class GetUserDataRequestTest extends \CTestCase
 {
-    /**
-     * @return GetUserDataRequest
-     */
-    private function getInstance()
+    protected function setUp(): void
     {
-        //\Yii::app()->params["pre_assessment_api_base_url"] = "http://example.com";
-        return new GetUserDataRequest(CSDClient::get());
+        parent::setUp();
+        // Request::__construct() reads these from the application params and
+        // throws when any of them is empty, so they must be populated first.
+        \Yii::app()->params["csd_api_key"] = "test-api-key";
+        \Yii::app()->params["csd_api_url"] = "http://example.com";
+        \Yii::app()->params["csd_api_timeout"] = "30";
     }
 
-    /** @test */
-    public function testGetActionName()
+    private function getInstance(): GetUserDataRequest
     {
-        $this->assertEquals("CSDAPI/api/staff?DomainUsername=WILLIAMSS",
+        return new GetUserDataRequest();
+    }
+
+    public function testGetActionNameBuildsTheStaffLookupPath(): void
+    {
+        $this->assertEquals(
+            "CSDAPI/api/staff?DomainUsername=WILLIAMSS",
             $this->getInstance()
                 ->setUsername("WILLIAMSS")
-                ->getActionName());
+                ->getActionName()
+        );
     }
 
-    /** @test */
-    public function testGetTimeout()
+    public function testGetTimeoutReturnsTheConfiguredValueAsInt(): void
     {
-        $this->assertIsNumeric($this->getInstance()->getTimeout());
+        $this->assertSame(30, $this->getInstance()->getTimeout());
+    }
+
+    public function testConstructorThrowsWhenARequiredSettingIsMissing(): void
+    {
+        \Yii::app()->params["csd_api_url"] = "";
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("csd_api_url not set");
+
+        new GetUserDataRequest();
     }
 }

--- a/tests/unit/components/SingletonTest.php
+++ b/tests/unit/components/SingletonTest.php
@@ -15,22 +15,37 @@
  * @license http://www.gnu.org/licenses/agpl-3.0.html The GNU Affero General Public License V3.0
  */
 
-namespace OEModule\CSDClient\tests\unit\components;
+namespace OEModule\mehstaffdb\tests\unit\components;
 
-use OEModule\CSDClient\components\Singleton;
+use OEModule\mehstaffdb\components\Singleton;
+
+/**
+ * Concrete subclasses used to exercise the abstract Singleton base.
+ * Each distinct subclass should resolve to its own single shared instance.
+ */
+class SingletonTestSubjectA extends Singleton
+{
+}
+
+class SingletonTestSubjectB extends Singleton
+{
+}
 
 class SingletonTest extends \CTestCase
 {
-    public function testGet()
+    public function testGetReturnsInstanceOfTheCalledClass(): void
     {
-        $stub1 = $this->getMockClass(Singleton::class, ["get"], [], "class1");
-        $stub2 = $this->getMockClass(Singleton::class, ["get"], [], "class2");
-        $obj1 = $stub1::get();
-        $obj2 = $stub2::get();
-        $this->assertNotSame($obj1, $obj2);
-        $this->assertInstanceOf($stub1, $obj1);
-        $this->assertInstanceOf($stub2, $obj2);
-        $obj3 = $stub1::get();
-        $this->assertSame($obj1, $obj3);
+        $this->assertInstanceOf(SingletonTestSubjectA::class, SingletonTestSubjectA::get());
+        $this->assertInstanceOf(SingletonTestSubjectB::class, SingletonTestSubjectB::get());
+    }
+
+    public function testGetReturnsTheSameInstanceOnRepeatedCalls(): void
+    {
+        $this->assertSame(SingletonTestSubjectA::get(), SingletonTestSubjectA::get());
+    }
+
+    public function testDifferentSubclassesResolveToDifferentInstances(): void
+    {
+        $this->assertNotSame(SingletonTestSubjectA::get(), SingletonTestSubjectB::get());
     }
 }

--- a/tests/unit/components/UserObserverTest.php
+++ b/tests/unit/components/UserObserverTest.php
@@ -15,55 +15,73 @@
  * @license http://www.gnu.org/licenses/agpl-3.0.html The GNU Affero General Public License V3.0
  */
 
-namespace OEModule\CSDClient\tests\unit\components;
-
-use OEModule\CSDClient\components\UserObserver;
-use OEModule\CSDClient\components\CSDClient\CSDClient;
+namespace OEModule\mehstaffdb\tests\unit\components;
 
 class UserObserverTest extends \OEDbTestCase
 {
-    public $fixtures = [
-        "user" => \User::class,
-    ];
-
     /** @var \CDbTransaction */
     private $transaction;
-    /** @var CSD */
-    private $api;
 
-    /*public function testClassCanBeFound()
-    {
-        $api = \Yii::app()->moduleAPI->get("CSDClient");
-        $this->assertInstanceOf(UserObserver::class, $api);
-    }*/
-
-    public function setUp()
+    protected function setUp(): void
     {
         $this->transaction = \Yii::app()->db->beginTransaction();
         parent::setUp();
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->transaction->rollback();
     }
 
-
-    /** @test */
-    public function testUpdateUser()
+    /**
+     * Invokes one of UserObserver's private methods for the purpose of testing.
+     *
+     * @param mixed ...$args
+     * @return mixed
+     */
+    private function invokePrivate(\UserObserver $observer, string $method, ...$args)
     {
-        $this->api = \Yii::app()->moduleAPI->get("CSDClient");
-        $this->api = $this->getMockBuilder(UserObserver::class)
-            ->setMethods(["getCSDClient"])
-            ->getMock();
-        $mockCSDClient = $this->getMockBuilder(CSDClient::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mockCSDClient->method("getUserData")->willReturn(json_encode(["hello" => "world"]));
-        $this->api->method("getCSDClient")->willReturn($mockCSDClient);
+        $reflection = new \ReflectionMethod(\UserObserver::class, $method);
+        $reflection->setAccessible(true);
+        return $reflection->invoke($observer, ...$args);
+    }
 
-        //$mock_user = $this->user("user1");
-        //$this->assertEquals($this->api->updateUser($mock_user), $mock_user);
+    public function testGetDoctorGradeFromJobTitleMapsKnownRoles(): void
+    {
+        $observer = new \UserObserver();
+
+        $this->assertSame(1, $this->invokePrivate($observer, "getDoctorGradeFromJobTitle", "Consultant"));
+        $this->assertSame(4, $this->invokePrivate($observer, "getDoctorGradeFromJobTitle", "Fellow"));
+        $this->assertSame(22, $this->invokePrivate($observer, "getDoctorGradeFromJobTitle", "Optometrist"));
+    }
+
+    public function testGetDoctorGradeFromJobTitleMatchesOnSubstring(): void
+    {
+        $observer = new \UserObserver();
+
+        // The lookup matches when the mapped description appears anywhere in the title.
+        $this->assertSame(1, $this->invokePrivate($observer, "getDoctorGradeFromJobTitle", "Locum Consultant"));
+    }
+
+    public function testGetDoctorGradeFromJobTitleDefaultsToOther(): void
+    {
+        $observer = new \UserObserver();
+
+        // 33 is the documented "Other" fallback for an unrecognised job title.
+        $this->assertSame(33, $this->invokePrivate($observer, "getDoctorGradeFromJobTitle", "Completely Unknown Title"));
+    }
+
+    public function testUpdateUserSkipsUsersListedAsLocal(): void
+    {
+        \Yii::app()->params["local_users"] = ["localadmin"];
+
+        $observer = $this->getMockBuilder(\UserObserver::class)
+            ->onlyMethods(["getCSDClient"])
+            ->getMock();
+        // A local user must short-circuit before any CSD lookup is attempted.
+        $observer->expects($this->never())->method("getCSDClient");
+
+        $this->assertNull($observer->updateUser(["username" => "localadmin"]));
     }
 }


### PR DESCRIPTION
Unit tests failed to run as they were using the wrong class names, and methods no longer compatible with latest PHPUnit.

Done:
- update to use correct classes
- Extended test coverage to give some semi-useful coverage. Previoulsy tests had no assertions or didn't cover anything meaningful

**Note:** Only test files are changed. Real files are purposefully untouched, despite them being rife for an update. The module is currently working in production (as far as we know), and is due for retirement in the future (hopefully) as it can be replaced by SSO.