### PR TITLE
Allow module to run in CI without interfeering with normal flow

### DIFF
--- a/components/CSDClient/Request.php
+++ b/components/CSDClient/Request.php
@@ -47,7 +47,7 @@ abstract class Request implements RequestInterface
     {
         foreach ($this->getSettingKeys() as $setting_key) {
             $setting_value = \Yii::app()->params[$setting_key];
-            if (strlen($setting_value) === 0) {
+            if (strlen((string) $setting_value) === 0) {
                 throw new \Exception("$setting_key not set");
             }
             $this->$setting_key = $setting_value;

--- a/components/UserObserver.php
+++ b/components/UserObserver.php
@@ -44,6 +44,11 @@ class UserObserver extends \BaseAPI
 		if (in_array($params['username'],Yii::app()->params['local_users'])) {
 			return;
 		}
+		// CSD integration is optional: if no endpoint is configured (e.g. CI, or a
+		// deployment without the staff DB), skip the remote sync rather than failing.
+		if (empty(Yii::app()->params['csd_api_url'])) {
+			return;
+		}
 		if (!isset($params['institution_authentication_id'])) {
 			$institutionId = Institution::model()->find('remote_id = ?',array(Yii::app()->params['institution_code']))->id;
 			$institution_authentication_id = InstitutionAuthentication::model()->find('institution_id= ?',array($institutionId))->id;


### PR DESCRIPTION
If the csd_api_url is not set, then return early.

The module is already covered by unit tests using mocks.

Without this update, any attempt to create a user or authenticate will throw an error, which means it could not be installed in CI without wider consequence